### PR TITLE
Temporary fix for issue #2.

### DIFF
--- a/EverythingCmdPal/Pages/Results.cs
+++ b/EverythingCmdPal/Pages/Results.cs
@@ -19,6 +19,7 @@ namespace EverythingCmdPal;
 
 internal sealed partial class Results : DynamicListPage
 {
+    private string _searchText = "";
     internal readonly SettingsManager _settings;
     public Results(SettingsManager settings)
     {
@@ -27,6 +28,17 @@ internal sealed partial class Results : DynamicListPage
         PlaceholderText = Resources.noquery;
         _settings = settings;
         ShowDetails = true;
+    }
+    public override string SearchText
+    {
+        get => _searchText;
+        set
+        {
+            if (_searchText == value) return;
+            var old = _searchText;
+            _searchText = value;
+            UpdateSearchText(old, value);
+        }
     }
 
     public override void UpdateSearchText(string oldSearch, string newSearch)


### PR DESCRIPTION
```csharp
public abstract class DynamicListPage : ListPage, IDynamicListPage, IListPage, IPage, ICommand, INotifyPropChanged, INotifyItemsChanged
{
    public override string SearchText
    {
        get
        {
            return base.SearchText;
        }
        set
        {
            string searchText = base.SearchText;
            base.SearchText = value;
            UpdateSearchText(searchText, value);
        }
    }

    public abstract void UpdateSearchText(string oldSearch, string newSearch);
}
```
# Bug from upstream: 

As noted in issue [#38829](https://github.com/microsoft/PowerToys/issues/38829), PageViewModel.FetchProperty unconditionally raises PropertyChanged(SearchText) before the model’s SearchText is actually updated, so DynamicListPage’s default setter ends up reassigning the bound TextBox.Text prematurely—and WinUI always moves the caret to the end whenever you set Text in code .

# Temporary Fix
By fully overriding SearchText and never calling base.SearchText = value, I completely bypass that race-y PropertyChanged + binding reassignment. Instead, I keep the query in our own private field and call UpdateSearchText(old, new) directly. this preserves real-time list updates while leaving the TextBox’s caret exactly where the user left it 
[GitHub](https://github.com/microsoft/PowerToys/issues/38829).

Also, since it's a temp fix, I wish it could be merged to a new branch.