### PR TITLE
[Feature] Change 'Extension' to 'Type' in the result page

### DIFF
--- a/EverythingCmdPal/Helpers/Query.cs
+++ b/EverythingCmdPal/Helpers/Query.cs
@@ -84,6 +84,8 @@ namespace EverythingCmdPal.Helpers
                 }
                 r.Icon ??= IconHelpers.FromRelativePath("Assets\\EverythingPt.svg");
 
+                r.FileType = Interop.Shell32Methods.GetFileTypeDescription(r.FullName);
+
                 resultsList.Add(r);
             }
             token.ThrowIfCancellationRequested();

--- a/EverythingCmdPal/Helpers/Result.cs
+++ b/EverythingCmdPal/Helpers/Result.cs
@@ -8,6 +8,7 @@ namespace EverythingCmdPal.Helpers
         internal string FilePath { get; set; }
         internal string FullName { get; set; }
         internal string Extension { get; set; }
+        internal string FileType { get; set; }
         internal IconInfo Icon { get; set; }
         internal bool IsFolder { get; set; }
         internal long SizeKB { get; set; }

--- a/EverythingCmdPal/Interop/Shell32Methods.cs
+++ b/EverythingCmdPal/Interop/Shell32Methods.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EverythingCmdPal.Interop
+{
+    internal class Shell32Methods
+    {
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct SHFILEINFO
+        {
+            public IntPtr hIcon;
+            public int iIcon;
+            public uint dwAttributes;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            public string szDisplayName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
+            public string szTypeName;
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern uint GetFileAttributes(string lpFileName);
+
+        [DllImport("shell32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr SHGetFileInfo(string pszPath, uint dwFileAttributes, ref SHFILEINFO psfi, uint cbFileInfo, uint uFlags);
+
+        private const uint SHGFI_TYPENAME = 0x000000400;
+        private const uint SHGFI_USEFILEATTRIBUTES = 0x000000010;
+
+        public static string GetFileTypeDescription(string path)
+        {
+            SHFILEINFO shinfo = new SHFILEINFO();
+
+            IntPtr result = SHGetFileInfo(path, GetFileAttributes(path), ref shinfo, (uint)Marshal.SizeOf(shinfo), SHGFI_TYPENAME | SHGFI_USEFILEATTRIBUTES);
+
+            if (result != IntPtr.Zero)
+            {
+                return shinfo.szTypeName;
+            }
+
+            return null;
+        }
+    }
+}

--- a/EverythingCmdPal/Pages/ResultsPage.cs
+++ b/EverythingCmdPal/Pages/ResultsPage.cs
@@ -75,10 +75,10 @@ internal partial class ResultsPage : DynamicListPage, IDisposable, IFallbackHand
                                         }
                                     },
                                     new DetailsElement() {
-                                        Key = "Extension",
+                                        Key = "Type",
                                         Data = new DetailsTags(){
                                             Tags=[
-                                                new Tag(r.Extension ?? string.Empty){
+                                                new Tag(r.FileType ?? string.Empty){
                                                     Foreground = ColorHelpers.FromRgb(51,51,51),
                                                     Background=ColorHelpers.FromRgb(224,204,179)},
                                             ]


### PR DESCRIPTION
Currently, the search results page displays a dedicated file extension field, which presents several issues:
- The extension field is empty when a folder is selected.
  
  <img width="1380" height="829" alt="screenshot: empty 'extension' field when folder selected" src="https://github.com/user-attachments/assets/4bd4683b-c065-4f69-9f63-3f02e306a7fd" />

- The dedicated field of extension duplicates the extension already present in the filename.
- File extensions are less user-friendly compared to descriptive file-type text.

This pull request adds support for displaying the user-friendly file type description (e.g., "Text Document", "JPEG Image") for search results, instead of just showing the file extension. The implementation uses Windows Shell32 interop to retrieve the file type, updates the data model to store it, and changes the UI to display this new information.

<img width="1380" height="829" alt="图片" src="https://github.com/user-attachments/assets/3fae07de-2dda-4415-9e3f-584ce0e2b088" />

<img width="1380" height="829" alt="图片" src="https://github.com/user-attachments/assets/a555e9f4-ab2e-41e8-a1fb-93da32542630" />





