### PR TITLE
[Feature] Add a filter in the result page

### DIFF
--- a/EverythingCmdPal/Pages/ResultsPage.cs
+++ b/EverythingCmdPal/Pages/ResultsPage.cs
@@ -15,6 +15,8 @@ internal partial class ResultsPage : DynamicListPage, IDisposable, IFallbackHand
     private readonly List<IListItem> _results = [];
     private readonly Lock _lock = new();
     private CancellationTokenSource _cts = new();
+    private readonly ResultsFilters _filters;
+    private string _searchText = string.Empty;
     internal string pre = string.Empty;
 
     public ResultsPage()
@@ -23,6 +25,9 @@ internal partial class ResultsPage : DynamicListPage, IDisposable, IFallbackHand
         Name = "Everything";
         PlaceholderText = Resources.noquery;
         ShowDetails = true;
+        _filters = new ResultsFilters();
+        _filters.PropChanged += OnFiltersChanged;
+        Filters = _filters;
     }
     public override IListItem[] GetItems() => [.. _results];
     public void UpdateQuery(string query)
@@ -111,12 +116,91 @@ internal partial class ResultsPage : DynamicListPage, IDisposable, IFallbackHand
     }
     public override void UpdateSearchText(string oldSearch, string newSearch)
     {
+        _searchText = newSearch;
         UpdateQuery(newSearch);
+    }
+
+    private void OnFiltersChanged(object? sender, IPropChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(Filters.CurrentFilterId))
+            return;
+
+        pre = _filters.GetPrefix();
+        UpdateQuery(_searchText);
     }
 
     public void Dispose()
     {
+        _filters.PropChanged -= OnFiltersChanged;
         _cts.Cancel();
         GC.SuppressFinalize(this);
+    }
+
+    private class ResultsFilters : Filters
+    {
+        private const string AllFilterId = "all";
+        private const string FolderFilterId = "folder";
+        private const string FileFilterId = "file";
+
+        private readonly List<(string Id, string Name, string Prefix)> _customFilters = [];
+
+        internal ResultsFilters()
+        {
+            CurrentFilterId = AllFilterId;
+
+            foreach (string key in Query.Settings.Filters.Keys)
+            {
+                string normalized = key.Trim();
+                if (normalized.Length == 0)
+                    continue;
+
+                string keyWithoutSuffix = normalized.EndsWith(':') ? normalized[..^1] : normalized;
+                string prefix = normalized.EndsWith(':') ? normalized : $"{normalized}:";
+                _customFilters.Add(($"custom:{keyWithoutSuffix}", string.Format(Resources.filter_custom, keyWithoutSuffix), prefix));
+            }
+        }
+
+        internal string GetPrefix()
+        {
+            return CurrentFilterId switch
+            {
+                AllFilterId => string.Empty,
+                FolderFilterId => "folder:",
+                FileFilterId => "file:",
+                _ => GetCustomPrefix(CurrentFilterId),
+            };
+        }
+
+        public override IFilterItem[] GetFilters()
+        {
+            List<IFilterItem> filters =
+            [
+                new Filter() { Id = AllFilterId, Name = Resources.filter_all, Icon = new IconInfo("\uE71C") },
+                new Filter() { Id = FolderFilterId, Name = Resources.filter_folders, Icon = new IconInfo("\uE8B7") },
+                new Filter() { Id = FileFilterId, Name = Resources.filter_files, Icon = new IconInfo("\uE8A5") },
+            ];
+
+            if (_customFilters.Count > 0)
+            {
+                filters.Add(new Separator());
+                foreach (var filter in _customFilters)
+                {
+                    filters.Add(new Filter() { Id = filter.Id, Name = filter.Name, Icon = new IconInfo("\uE71C") });
+                }
+            }
+
+            return [.. filters];
+        }
+
+        private string GetCustomPrefix(string filterId)
+        {
+            foreach (var filter in _customFilters)
+            {
+                if (filter.Id == filterId)
+                    return filter.Prefix;
+            }
+
+            return string.Empty;
+        }
     }
 }

--- a/EverythingCmdPal/Properties/Resources.Designer.cs
+++ b/EverythingCmdPal/Properties/Resources.Designer.cs
@@ -198,6 +198,42 @@ namespace EverythingCmdPal.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All.
+        /// </summary>
+        internal static string filter_all {
+            get {
+                return ResourceManager.GetString("filter_all", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom {0}.
+        /// </summary>
+        internal static string filter_custom {
+            get {
+                return ResourceManager.GetString("filter_custom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Files.
+        /// </summary>
+        internal static string filter_files {
+            get {
+                return ResourceManager.GetString("filter_files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folders.
+        /// </summary>
+        internal static string filter_folders {
+            get {
+                return ResourceManager.GetString("filter_folders", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to filters.toml.
         /// </summary>
         internal static string filter_path {

--- a/EverythingCmdPal/Properties/Resources.he-IL.resx
+++ b/EverythingCmdPal/Properties/Resources.he-IL.resx
@@ -266,6 +266,18 @@
   <data name="open_folder" xml:space="preserve">
     <value>פתח תיקייה</value>
   </data>
+  <data name="filter_all" xml:space="preserve">
+    <value>הכל</value>
+  </data>
+  <data name="filter_folders" xml:space="preserve">
+    <value>תיקיות</value>
+  </data>
+  <data name="filter_files" xml:space="preserve">
+    <value>קבצים</value>
+  </data>
+  <data name="filter_custom" xml:space="preserve">
+    <value>מותאם אישית: {0}</value>
+  </data>
   <data name="filter_path" xml:space="preserve">
     <value>filters.toml</value>
   </data>

--- a/EverythingCmdPal/Properties/Resources.ko-KR.resx
+++ b/EverythingCmdPal/Properties/Resources.ko-KR.resx
@@ -266,6 +266,18 @@
   <data name="open_folder" xml:space="preserve">
     <value>경로 열기</value>
   </data>
+  <data name="filter_all" xml:space="preserve">
+    <value>전체</value>
+  </data>
+  <data name="filter_folders" xml:space="preserve">
+    <value>폴더</value>
+  </data>
+  <data name="filter_files" xml:space="preserve">
+    <value>파일</value>
+  </data>
+  <data name="filter_custom" xml:space="preserve">
+    <value>사용자 지정: {0}</value>
+  </data>
   <data name="filter_path" xml:space="preserve">
     <value>filters.toml</value>
   </data>

--- a/EverythingCmdPal/Properties/Resources.resx
+++ b/EverythingCmdPal/Properties/Resources.resx
@@ -266,6 +266,18 @@ Separate program path and argument with comma (,) where $P$ represents the path 
   <data name="open_folder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="filter_all" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="filter_folders" xml:space="preserve">
+    <value>Folders</value>
+  </data>
+  <data name="filter_files" xml:space="preserve">
+    <value>Files</value>
+  </data>
+  <data name="filter_custom" xml:space="preserve">
+    <value>Custom: {0}</value>
+  </data>
   <data name="filter_path" xml:space="preserve">
     <value>filters.toml</value>
   </data>

--- a/EverythingCmdPal/Properties/Resources.zh-CN.resx
+++ b/EverythingCmdPal/Properties/Resources.zh-CN.resx
@@ -261,4 +261,16 @@
   <data name="open_folder" xml:space="preserve">
     <value>打开文件夹</value>
   </data>
+  <data name="filter_all" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="filter_folders" xml:space="preserve">
+    <value>文件夹</value>
+  </data>
+  <data name="filter_files" xml:space="preserve">
+    <value>文件</value>
+  </data>
+  <data name="filter_custom" xml:space="preserve">
+    <value>自定义：{0}</value>
+  </data>
 </root>

--- a/EverythingCmdPal/Properties/Resources.zh-HK.resx
+++ b/EverythingCmdPal/Properties/Resources.zh-HK.resx
@@ -261,4 +261,16 @@
   <data name="open_folder" xml:space="preserve">
     <value>開啟資料夾</value>
   </data>  
+  <data name="filter_all" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="filter_folders" xml:space="preserve">
+    <value>資料夾</value>
+  </data>
+  <data name="filter_files" xml:space="preserve">
+    <value>檔案</value>
+  </data>
+  <data name="filter_custom" xml:space="preserve">
+    <value>自訂：{0}</value>
+  </data>
 </root>

--- a/EverythingCmdPal/Properties/Resources.zh-TW.resx
+++ b/EverythingCmdPal/Properties/Resources.zh-TW.resx
@@ -261,4 +261,16 @@
   <data name="open_folder" xml:space="preserve">
     <value>開啟資料夾</value>
   </data>  
+  <data name="filter_all" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="filter_folders" xml:space="preserve">
+    <value>資料夾</value>
+  </data>
+  <data name="filter_files" xml:space="preserve">
+    <value>檔案</value>
+  </data>
+  <data name="filter_custom" xml:space="preserve">
+    <value>自訂：{0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Currently, users are required to manually prepend prefixes (e.g., `Doc:`) to the search queries to filter for specific file types. This approach is not particularly user-friendly and can be unintuitive for new users. 

This PR improves the experience by introducing a filter widget, similar to the one found in cmdpal's built-in file search extension. This allows for a more intuitive filtering process without the need for manual prefixing, allowing users to filter search results by type (All, Folders, Files) or by custom filters defined in `filters.toml`.

The implementation includes a new `ResultsFilters` class, updates to the UI to support filter changes, and localization support for new filter labels across multiple languages. Related localization resources are also updated in this PR.

<img width="1380" height="830" alt="screenshot: filter" src="https://github.com/user-attachments/assets/49c111ee-22ee-4967-87c2-c42118dd7530" />
