### PR TITLE
Add toggle to enable/disable delete shortcut

### DIFF
--- a/EverythingCmdPal/Commands/CommandHandler.cs
+++ b/EverythingCmdPal/Commands/CommandHandler.cs
@@ -33,11 +33,6 @@ namespace EverythingCmdPal.Commands
                 {
                     RequestedShortcut = KeyChordHelpers.FromModifiers(true, false, false, false, (int)VirtualKey.N, 0),
                 });
-            if (Query.Settings.EnableDelete)
-                items.Add(new CommandContextItem(new DeleteCommand(fullPath, isFolder)) 
-                {
-                    RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.Delete, 0),
-                });
             if (CanFileBeRunAsAdmin(fullPath))
             {
                 items.Add(new CommandContextItem(new RunAdminCommand(fullPath, isFolder))
@@ -69,6 +64,12 @@ namespace EverythingCmdPal.Commands
                 //new CommandContextItem(new ContextMenuCommand(fullPath, isFolder)) {
                 //    RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.M, 0)
                 //},
+                new CommandContextItem(new DeleteCommand(fullPath, isFolder)) 
+                {
+                    RequestedShortcut = Query.Settings.EnableDelete
+                        ? KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.Delete, 0)
+                        : default,
+                },
                 new CommandContextItem(new PropertiesCommand(fullPath)) {
                     RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.I, 0)
                 },

--- a/EverythingCmdPal/Commands/CommandHandler.cs
+++ b/EverythingCmdPal/Commands/CommandHandler.cs
@@ -33,7 +33,11 @@ namespace EverythingCmdPal.Commands
                 {
                     RequestedShortcut = KeyChordHelpers.FromModifiers(true, false, false, false, (int)VirtualKey.N, 0),
                 });
-
+            if (Query.Settings.EnableDelete)
+                items.Add(new CommandContextItem(new DeleteCommand(fullPath, isFolder)) 
+                {
+                    RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.Delete, 0),
+                });
             if (CanFileBeRunAsAdmin(fullPath))
             {
                 items.Add(new CommandContextItem(new RunAdminCommand(fullPath, isFolder))
@@ -65,9 +69,6 @@ namespace EverythingCmdPal.Commands
                 //new CommandContextItem(new ContextMenuCommand(fullPath, isFolder)) {
                 //    RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.M, 0)
                 //},
-                new CommandContextItem(new DeleteCommand(fullPath, isFolder)) {
-                    RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.Delete, 0)
-                },
                 new CommandContextItem(new PropertiesCommand(fullPath)) {
                     RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.I, 0)
                 },

--- a/EverythingCmdPal/Commands/CommandHandler.cs
+++ b/EverythingCmdPal/Commands/CommandHandler.cs
@@ -64,8 +64,7 @@ namespace EverythingCmdPal.Commands
                 //new CommandContextItem(new ContextMenuCommand(fullPath, isFolder)) {
                 //    RequestedShortcut = KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.M, 0)
                 //},
-                new CommandContextItem(new DeleteCommand(fullPath, isFolder)) 
-                {
+                new CommandContextItem(new DeleteCommand(fullPath, isFolder)) {
                     RequestedShortcut = Query.Settings.EnableDelete
                         ? KeyChordHelpers.FromModifiers(true,false,false,false, (int)VirtualKey.Delete, 0)
                         : default,

--- a/EverythingCmdPal/Helpers/SettingsManager.cs
+++ b/EverythingCmdPal/Helpers/SettingsManager.cs
@@ -69,6 +69,12 @@ namespace EverythingCmdPal.Helpers
             Resources.show_more_description,
             true);
 
+        private readonly ToggleSetting _enableDelete = new(
+            Namespaced(nameof(EnableDelete)),
+            Resources.enable_delete,
+            Resources.enable_delete_description,
+            true);
+
         private readonly TextSetting _exe = new(
             Namespaced(nameof(Exe)),
             Resources.exe,
@@ -101,6 +107,7 @@ namespace EverythingCmdPal.Helpers
         public bool Regex => _regex.Value;
         public bool RunAs => _runas.Value;
         public bool ShowMore => _showMore.Value;
+        public bool EnableDelete => _enableDelete.Value;
         public string Exe => _exe.Value ?? string.Empty;
         public bool EnableSend => _bSendto.Value;
         public string Sendto => _sendto.Value ?? string.Empty;
@@ -127,6 +134,7 @@ namespace EverythingCmdPal.Helpers
             Settings.Add(_regex);
             Settings.Add(_runas);
             Settings.Add(_showMore);
+            Settings.Add(_enableDelete);
             Settings.Add(_exe);
             Settings.Add(_bSendto);
             Settings.Add(_sendto);

--- a/EverythingCmdPal/Properties/Resources.Designer.cs
+++ b/EverythingCmdPal/Properties/Resources.Designer.cs
@@ -59,6 +59,16 @@ namespace EverythingCmdPal.Properties {
                 resourceCulture = value;
             }
         }
+        internal static string enable_delete {
+            get {
+                return ResourceManager.GetString("enable_delete", resourceCulture);
+            }
+        }
+        internal static string enable_delete_description {
+            get {
+                return ResourceManager.GetString("enable_delete_description", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Browse.

--- a/EverythingCmdPal/Properties/Resources.resx
+++ b/EverythingCmdPal/Properties/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="enable_delete" xml:space="preserve">
+    <value>Enable Delete</value>
+  </data>
+  <data name="enable_delete_description" xml:space="preserve">
+    <value>Enable the deletion shortcut (Ctrl+Delete).</value>
+  </data>
   <data name="browse" xml:space="preserve">
     <value>Browse</value>
   </data>

--- a/EverythingCmdPal/Properties/Resources.resx
+++ b/EverythingCmdPal/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="enable_delete" xml:space="preserve">
-    <value>Enable Delete</value>
+    <value>Enable Delete shortcut</value>
   </data>
   <data name="enable_delete_description" xml:space="preserve">
     <value>Enable the deletion shortcut (Ctrl+Delete).</value>


### PR DESCRIPTION
Having the delete shortcut on by default with no way to change it annoyed me, I kept hitting it by accident.

This PR adds a toggle setting to enable or disable the delete shortcut. It's enabled by default, so the behaviour is unchanged from the current one. If the setting is on, then the delete shortcut (`Ctrl`+`Delete`) works as usual. If the setting is off, then the delete shortcut is unassigned, but deletion can still be performed from the context menu.

<img width="582" height="504" alt="image" src="https://github.com/user-attachments/assets/636e7cdf-d82c-4417-a80d-280eea54eb32" />

Note this feature requires new translated strings.

